### PR TITLE
Dá ao grupo de WhatsApp o lugar de canal principal da comunidade

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,14 +13,14 @@ Nesta fase, é especialmente valiosa a experiência em:
 
 ## Onde a conversa acontece
 
-- **GitHub Issues** é o canal **canônico** do projeto — onde propostas e decisões ficam registradas e pesquisáveis.
-- **GitHub Discussions**, quando estiver habilitado neste repositório, é um espaço complementar para conversas mais abertas.
-- Também existe um **grupo de WhatsApp** da comunidade: <https://chat.whatsapp.com/LPxRX9ivXUm6VF4atVKYW7> (o link pode expirar — se não funcionar, abra uma Issue pedindo um novo). O WhatsApp é bom para conversa em tempo real, mas **decisões do projeto são registradas no repositório**, não apenas discutidas por lá.
+- O dia a dia do projeto acontece no **grupo de WhatsApp** da comunidade: <https://chat.whatsapp.com/LPxRX9ivXUm6VF4atVKYW7> (o link pode expirar — se não funcionar, abra uma Issue pedindo um novo). É lá que as conversas nascem e que a maior parte das definições é debatida hoje.
+- **GitHub Issues** é a porta pública do projeto: quem chega de fora propõe, reporta e pergunta por ali, sem precisar de convite, e tudo fica registrado e pesquisável. É o caminho que tende a ganhar força conforme o projeto crescer.
+- **O que vira decisão é registrado em [`docs/decisions/`](./docs/decisions/) e nas atas de [`docs/reunioes/`](./docs/reunioes/).** Conversa — em qualquer canal — não é registro.
 
 ## Como participar de uma decisão técnica
 
 1. **Leia o registro da decisão** em [`docs/decisions/`](./docs/decisions/). Ele traz o contexto, os critérios em disputa e as teses já apresentadas — para que você não precise repetir o que já foi dito.
-2. **Comente na Issue vinculada**, ou abra uma Issue do tipo *Proposta de decisão técnica* se sua contribuição for uma tese nova.
+2. **Traga sua posição ao debate** — no grupo de WhatsApp, numa reunião ou numa Issue. Se sua contribuição é uma tese nova, uma Issue do tipo *Proposta de decisão técnica* a deixa pública e pesquisável desde o início.
 3. **Assine sua posição.** Argumentos entram no registro permanente com o nome de quem os defende. O projeto não atribui posições a pessoas por conta própria — nem a partir de transcrição de reunião.
 
 Teses vencidas **permanecem no registro**. Discordar e perder não apaga sua contribuição do histórico do projeto: ela fica lá, explicando o que já foi pesado.
@@ -41,4 +41,4 @@ A documentação do projeto é escrita em **português**. Código, identificador
 
 ## Código de conduta
 
-Toda interação no projeto — Issues, Discussions, WhatsApp — segue o [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md).
+Toda interação no projeto — no grupo de WhatsApp, em Issues e Pull Requests, nas reuniões — segue o [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -28,10 +28,10 @@ Quando a composição estabilizar e houver consentimento de cada pessoa, um docu
 
 ## Como as decisões técnicas são tomadas
 
-1. **A proposta é pública.** Toda decisão de arquitetura começa numa Issue, antes de virar decisão.
+1. **Toda decisão termina em registro público.** A conversa nasce onde nascer — hoje, no grupo de WhatsApp e nas reuniões — e nenhuma decisão existe para o projeto enquanto não estiver registrada em [`docs/decisions/`](./docs/decisions/).
 2. **O debate é registrado.** Decisões relevantes são gravadas em [`docs/decisions/`](./docs/decisions/), com contexto, consequências assumidas e — obrigatoriamente — as alternativas descartadas e o motivo.
 3. **Teses vencidas não são apagadas.** Elas permanecem no registro. É o que permite a uma revisão futura saber o que já foi pesado, e é o que garante a quem discordou que sua posição não foi varrida para debaixo do tapete.
-4. **Uma decisão não é considerada tomada** enquanto quem participou do debate não tiver tido oportunidade real de se posicionar. Encaminhamento verbal ao final de uma reunião, com participantes ausentes, não fecha decisão.
+4. **Uma decisão não é considerada tomada** enquanto quem participou do debate não tiver tido oportunidade real de se posicionar. Encaminhamento verbal ao final de uma reunião, com participantes ausentes, não fecha decisão — e uma conversa no grupo encerrada sem tempo razoável para os envolvidos se posicionarem também não.
 5. **Decisões são reversíveis, com custo.** Uma decisão aceita pode ser substituída por outra; o documento antigo ganha um aviso apontando para o novo, e não é reescrito.
 
 Argumentos **não são atribuídos nominalmente** a partir de transcrição de reunião: transcrições automáticas erram, e atribuir publicamente uma posição técnica a alguém com base nelas é injusto. Atribuição é sempre de quem assina.
@@ -46,7 +46,7 @@ Espelhando o que está em [`licensing.md`](./docs/licensing.md):
 
 - A versão do OpenClinic sob AGPL-3.0 permanecerá sempre completa e funcional.
 - Qualquer CLA (acordo de licenciamento de contribuidor) será publicado para comentário público antes de passar a ser exigido.
-- Decisões relevantes do projeto serão registradas publicamente (em Issues do GitHub e em [`docs/decisions/`](./docs/decisions/), não apenas em conversas de canais como o WhatsApp — veja [`CONTRIBUTING.md`](./CONTRIBUTING.md)).
+- Decisões relevantes do projeto serão registradas publicamente (em [`docs/decisions/`](./docs/decisions/) e nas atas de [`docs/reunioes/`](./docs/reunioes/), não apenas em conversas de canais como o WhatsApp — veja [`CONTRIBUTING.md`](./CONTRIBUTING.md)).
 
 ## Titularidade
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ Um contraponto aos prontuários de mercado que fecham seu ecossistema e não lib
 [![Licença](https://img.shields.io/badge/licen%C3%A7a-AGPL--3.0-2E7D9A?style=flat-square)](./LICENSE)
 [![Status](https://img.shields.io/badge/status-pr%C3%A9--alfa-E8A33D?style=flat-square)](./docs/roadmap.md)
 [![Padrão](https://img.shields.io/badge/interoperabilidade-HL7%20FHIR-3B6FB0?style=flat-square)](./docs/decisions/0001-fhir-como-padrao-de-dados.md)
-[![Comunidade](https://img.shields.io/badge/comunidade-entrar%20no%20WhatsApp-25D366?style=flat-square&logo=whatsapp&logoColor=white)](https://chat.whatsapp.com/LPxRX9ivXUm6VF4atVKYW7)
+
+[![Entrar no grupo de WhatsApp](https://img.shields.io/badge/ENTRAR%20NO%20GRUPO%20DE%20WHATSAPP-25D366?style=for-the-badge&logo=whatsapp&logoColor=white)](https://chat.whatsapp.com/LPxRX9ivXUm6VF4atVKYW7)
+
+*É no grupo que a conversa do projeto acontece.*
 
 </div>
 
@@ -74,11 +77,11 @@ Detalhes em [`GOVERNANCE.md`](./GOVERNANCE.md).
 
 ## Como participar
 
-**Abra uma [Issue](../../issues).** É o canal oficial e pesquisável do projeto.
+**A conversa do projeto acontece no [grupo de WhatsApp](https://chat.whatsapp.com/LPxRX9ivXUm6VF4atVKYW7) — entre.** Se o link estiver expirado, avise por uma [Issue](../../issues).
 
-A contribuição mais valiosa hoje é **ajudar a fechar as decisões que ainda estão em aberto** — elas estão marcadas como tal no [índice de decisões](./docs/decisions/), e são as mais caras de reverter depois. Comente na Issue da decisão e assine sua posição.
+Quem chega de fora, ou prefere um canal público e permanente, **abre uma [Issue](../../issues)** — é a porta registrada e pesquisável do projeto, e o time responde por lá.
 
-Também há um **[grupo de WhatsApp da comunidade](https://chat.whatsapp.com/LPxRX9ivXUm6VF4atVKYW7)** para conversa em tempo real — mas decisão do projeto se registra aqui, não lá. Se o link estiver expirado, avise por uma Issue.
+A contribuição mais valiosa hoje é **ajudar a fechar as decisões que ainda estão em aberto** — elas estão marcadas como tal no [índice de decisões](./docs/decisions/), e são as mais caras de reverter depois. Traga sua posição ao grupo ou registre-a numa Issue: posição assinada entra no registro da decisão.
 
 Experiência especialmente bem-vinda: **HL7 FHIR e interoperabilidade em saúde**, **modelagem de dados clínicos**, **segurança da informação em dado sensível** e **quem já operou um prontuário na prática** e sabe onde dói. Guia completo em [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 

--- a/docs/decisions/0005-linguagem-do-backend.md
+++ b/docs/decisions/0005-linguagem-do-backend.md
@@ -91,7 +91,7 @@ Isso é **compatível** com o núcleo neutro descrito no `vision.md` e com o enq
 
 Esta decisão está aberta e o registro acima é público justamente para que o debate continue por escrito.
 
-- **Para assinar sua posição:** comente na Issue vinculada ou abra um Pull Request adicionando seu argumento com seu nome nesta seção. O projeto não atribui argumentos a pessoas a partir de transcrição de reunião.
-- **Para trazer uma tese nova:** abra uma Issue do tipo *Proposta de decisão técnica*.
+- **Para assinar sua posição:** abra um Pull Request adicionando seu argumento com seu nome nesta seção, ou deixe-o escrito numa Issue. Posição debatida no grupo de WhatsApp ou em reunião entra no registro assim — por escrito e assinada: o projeto não atribui argumentos a pessoas a partir de transcrição de reunião.
+- **Para trazer uma tese nova:** leve-a ao grupo de WhatsApp ou abra uma Issue do tipo *Proposta de decisão técnica*.
 
 Quando houver decisão, este documento passa a **Aceita**, com a justificativa registrada. As teses vencidas **permanecem aqui** — elas explicam por que o projeto é como é, e permitem que uma revisão futura saiba o que já foi pesado.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -26,12 +26,12 @@ Esta tabela e a do [`README` do projeto](../../README.md) são os dois únicos l
 
 ## Como propor uma decisão
 
-1. Abra uma [Issue](https://github.com/iniciativa-openclinic/openclinic/issues/new/choose) do tipo **Proposta de decisão técnica**, para que o debate aconteça em público.
+1. Leve a proposta a debate — no grupo de WhatsApp (link em [`CONTRIBUTING.md`](../../CONTRIBUTING.md)), numa reunião ou numa [Issue](https://github.com/iniciativa-openclinic/openclinic/issues/new/choose) do tipo **Proposta de decisão técnica**. A Issue é o caminho de quem chega de fora: pública e pesquisável desde o primeiro dia.
 2. Quando houver convergência, abra um Pull Request criando o arquivo `NNNN-titulo-curto.md` nesta pasta, seguindo a estrutura dos existentes.
 3. O número é o próximo da sequência e não se reaproveita, mesmo que a decisão seja depois substituída.
 
 ## Como registrar sua posição numa decisão em aberto
 
-Decisões marcadas como **Em aberto** têm uma seção de posições registradas. Se você participou do debate e quer que seu argumento fique no registro **com seu nome**, comente na Issue vinculada ou abra um Pull Request adicionando sua posição.
+Decisões marcadas como **Em aberto** têm uma seção de posições registradas. O debate pode acontecer em qualquer canal — grupo de WhatsApp, reunião, Issue —, mas posição só entra no registro **por escrito e assinada**: abra um Pull Request adicionando a sua, ou deixe-a escrita numa Issue para ser incorporada com seu nome.
 
 O projeto não atribui argumentos a pessoas por conta própria a partir de transcrição de reunião: a atribuição é sempre de quem assina.

--- a/docs/modulos.md
+++ b/docs/modulos.md
@@ -1,7 +1,7 @@
 # Arquitetura de módulos da V1
 
 > [!IMPORTANT]
-> **Este documento é uma proposta, não uma decisão.** Ele traduz os requisitos de produto ([`prd.md`](./prd.md)) em módulos, entidades e regras de negócio, para revisão da comunidade técnica. Discordâncias e lacunas devem virar Issue ou Pull Request. O que a revisão confirmar passa a orientar o desenho do esquema de banco e da API.
+> **Este documento é uma proposta, não uma decisão.** Ele traduz os requisitos de produto ([`prd.md`](./prd.md)) em módulos, entidades e regras de negócio, para revisão da comunidade técnica. Discordâncias e lacunas: traga-as ao grupo de WhatsApp ou abra uma Issue ou Pull Request — os canais estão em [`CONTRIBUTING.md`](../CONTRIBUTING.md). O que a revisão confirmar passa a orientar o desenho do esquema de banco e da API.
 
 ## Como ler este documento
 


### PR DESCRIPTION
O README ganha um botão de entrada no grupo logo no topo, e a seção de participação passa a apontar primeiro para ele. CONTRIBUTING, GOVERNANCE e os registros de decisão alinham-se à prática real do projeto: a conversa nasce onde nascer -- hoje, no grupo de WhatsApp e nas reuniões -- e as Issues ficam como a porta pública de entrada, o caminho de quem chega de fora.

A regra de governança inverte de "toda decisão começa numa Issue" para "toda decisão termina em registro público": o que vira decisão é registrado em docs/decisions/ e nas atas de docs/reunioes/, e conversa, em qualquer canal, não é registro. Uma conversa no grupo encerrada sem tempo razoável para os envolvidos se posicionarem também não fecha decisão.

## O que muda

<!-- Descreva o que este Pull Request faz. -->

## Por quê

<!-- Qual problema resolve, ou a que Issue/decisão responde. -->

Relacionado a: <!-- #número da Issue, ou docs/decisions/NNNN-... -->

## Checklist

- [ ] Se este PR **cria ou altera uma decisão técnica**, ele inclui o arquivo correspondente em `docs/decisions/`, com contexto, consequências e alternativas descartadas.
- [ ] Se este PR **substitui uma decisão anterior**, o documento antigo foi marcado como substituído — e não reescrito nem apagado.
- [ ] Os links internos da documentação continuam válidos.
- [ ] Se este PR **muda a API**, o contrato OpenAPI foi atualizado neste mesmo PR.
- [ ] Concordo que minha contribuição seja distribuída sob os [termos de licenciamento do projeto](https://github.com/iniciativa-openclinic/openclinic/blob/main/docs/licensing.md).
